### PR TITLE
PB-17: Setup Module Development Repo

### DIFF
--- a/.ddev/commands/web/install
+++ b/.ddev/commands/web/install
@@ -4,5 +4,5 @@
 ## Usage: install
 ## Example: "ddev install"
 
-drush site:install standard --account-name=admin --account-pass=admin --site-name="Drupal 10" -y
+drush site:install standard --account-name=admin --account-pass=admin --site-name="PubMod" -y
 drush en admin_toolbar admin_toolbar_tools config_inspector devel

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -11,7 +11,7 @@ additional_fqdns: []
 database:
   type: mariadb
   version: "10.4"
-nfs_mount_enabled: true
+nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: "2"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -11,7 +11,6 @@ additional_fqdns: []
 database:
   type: mariadb
   version: "10.4"
-nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: "2"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,4 @@
-name: drupal-10-development
+name: pubmod
 type: drupal10
 docroot: web
 php_version: "8.1"
@@ -6,7 +6,7 @@ webserver_type: nginx-fpm
 router_http_port: "80"
 router_https_port: "443"
 xdebug_enabled: false
-additional_hostnames: ["d10"]
+additional_hostnames: []
 additional_fqdns: []
 database:
   type: mariadb

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-  "name": "palantirnet/drupal-10-development",
+  "name": "palantirnet/pubmod",
   "description": "A minimal project build for Drupal 10 module development.",
   "type": "project",
   "license": "GPL-2.0-or-later",
-  "homepage": "https://github.com/palantirnet/drupal-10-development",
+  "homepage": "https://github.com/palantirnet/pubmod",
   "repositories": [
     {
       "type": "composer",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -37,7 +37,7 @@
      SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
      external DDev URL so you can follow the links directly.
     -->
-    <env name="BROWSERTEST_OUTPUT_BASE_URL" value="https://d10.ddev.site"/>
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value="https://pubmod.ddev.site"/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->


### PR DESCRIPTION
Setup this fork of `drupal-10-development` for use with PubMod, including:

* Renames the project in DDEV and Composer config.
* Updates the URL for phpunit tests.
* Changes the site name during Drupal install.
* Removes config that forces NFS to be used by DDEV.